### PR TITLE
Fix small bugs within dump_frames.py

### DIFF
--- a/dump_frames.py
+++ b/dump_frames.py
@@ -116,9 +116,11 @@ def dump_frames(video_path, output_directory, frames_per_second):
                 "Images for {} don't seem to be dumped properly!".format(
                     video_path))
 
+
 def dump_frames_star(args):	
     """Calls dump_frames after unpacking arguments."""	
     return dump_frames(*args)
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -129,7 +131,7 @@ def main():
                         default=None,
                         help='Directory to output frames to.')
     parser.add_argument('--fps',
-                        default=None,
+                        default=1,
                         help=('Number of frames to output per second. If 0, '
                              'dumps all frames in the clip.'))
     parser.add_argument('--num-workers', type=int, default=4)

--- a/dump_frames.py
+++ b/dump_frames.py
@@ -117,8 +117,8 @@ def dump_frames(video_path, output_directory, frames_per_second):
                     video_path))
 
 
-def dump_frames_star(args):	
-    """Calls dump_frames after unpacking arguments."""	
+def dump_frames_star(args):
+    """Calls dump_frames after unpacking arguments."""
     return dump_frames(*args)
 
 

--- a/dump_frames.py
+++ b/dump_frames.py
@@ -38,7 +38,7 @@ def frames_already_dumped(video_path,
         return False
 
     # Ensure that info file is valid.
-    with open(expected_info_path, 'rb') as info_file:
+    with open(expected_info_path, 'r') as info_file:
         info = json.load(info_file)
     info_valid = info['frames_per_second'] == expected_frames_per_second \
         and info['input_video_path'] == os.path.abspath(video_path)
@@ -83,9 +83,9 @@ def dump_frames(video_path, output_directory, frames_per_second):
         frames_per_second = clip.fps
 
     frames_already_dumped_helper = lambda: \
-            frames_already_dumped(video_path, output_directory,
-                                  frames_per_second, info_path,
-                                  name_format, clip.duration)
+        frames_already_dumped(video_path, output_directory,
+                              frames_per_second, info_path,
+                              name_format, clip.duration)
 
     if frames_already_dumped_helper():
         logging.info('Frames for {} exist, skipping...'.format(video_path))
@@ -96,7 +96,8 @@ def dump_frames(video_path, output_directory, frames_per_second):
         if extract_all_frames:
             cmd = ['ffmpeg', '-i', video_path, name_format]
         else:
-            cmd = ['ffmpeg', '-i', video_path, '-vf', '"fps=%s"', name_format]
+            cmd = ['ffmpeg', '-i', video_path, '-vf', 
+                   'fps={}'.format(frames_per_second), name_format]
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         successfully_wrote_images = True
     except Exception as e:


### PR DESCRIPTION
Found a couple small bugs within dump_frames.py while I was using it tonight. Let me know if in case I'm wrong and these are actually features. :)

Changelist:
- Indexing in the generation of filenames to check is off by 1
- FFmpeg command is missing a substitution operator
- Shortened flag from super long string to "fps"
- Flipped unintuitive default behaviour for FPS from 1 to None, which dumps all frames